### PR TITLE
Inject cheeky satire into code checks

### DIFF
--- a/.github/workflows/astroturf.yml
+++ b/.github/workflows/astroturf.yml
@@ -1,4 +1,4 @@
-name: Astroturf
+name: Astroturf: Synthetic Grassroots Maintenance
 
 on:
   schedule:
@@ -10,20 +10,21 @@ permissions:
 
 jobs:
   astroturf:
+    name: Turf the Narrative (Totally Organic)
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout (rolling out the green carpet)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Configure git user
+      - name: Set up Bot Persona (very human, definitely)
         run: |
           git config user.name "Astroturf Bot"
           git config user.email "astroturf-bot@users.noreply.github.com"
-      - name: Run astroturf
+      - name: Sow Synthetic Seeds
         id: turf
         uses: ./.github/actions/astroturf
-      - name: Commit and push if changed
+      - name: Commit and Push (if the crowd shows up)
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             git add -A
@@ -32,3 +33,30 @@ jobs:
           else
             echo "No changes to commit."
           fi
+      - name: Announce Push (Chaos Mode vibes?)
+        if: ${{ (github.ref_name == 'main' || github.ref_name == 'master') }}
+        uses: actions/github-script@v7
+        env:
+          TURF_COMMIT_MESSAGE: ${{ steps.turf.outputs.commit_message }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const sha = context.sha;
+            // Fetch last commit details
+            const { data: commit } = await github.rest.repos.getCommit({ owner, repo, ref: sha });
+            const lastMessage = commit.commit.message || '';
+            // Only comment if this run actually committed using the turf message
+            if (lastMessage.trim() === (process.env.TURF_COMMIT_MESSAGE || '').trim()) {
+              await github.rest.repos.createCommitComment({
+                owner,
+                repo,
+                commit_sha: sha,
+                body: [
+                  '🧪 CHAOS MODE ADJACENT: The Astroturf bot just pushed straight to ' + context.ref + '.',
+                  '',
+                  'Relax, this is a scheduled top-up of synthetic enthusiasm. If you were expecting a PR,',
+                  'consider this the “director’s cut” where we skip review for dramatic effect.'
+                ].join('\n')
+              });
+            }

--- a/.github/workflows/garden.yml
+++ b/.github/workflows/garden.yml
@@ -1,4 +1,4 @@
-name: Garden Keeper
+name: Garden Keeper: Photosynthesis-as-a-Service
 
 on:
   schedule:
@@ -17,29 +17,49 @@ permissions:
 
 jobs:
   tend-garden:
+    name: Tend the Garden (Weed out entropy)
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout (watering can not included)
         uses: actions/checkout@v4
 
-      - name: Setup Python
+      - name: Setup Python (snake charming)
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
-      - name: Install deps
+      - name: Install Dependencies (miracle grow edition)
         run: |
           python -m pip install --upgrade pip
           pip install pillow
 
-      - name: Run garden script
+      - name: Run Garden Script (watch the weeds whisper)
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           python scripts/garden_bot.py
 
-      - name: Commit and push changes
+      - name: PR Theatrics (play up the absurdity)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) return;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: [
+                '🌱 Behold: automated horticulture has entered the chat.',
+                '',
+                'This check ensures the garden is immaculately chaotic. If anything fails,',
+                'assume the weeds unionized and demand better sunlight.'
+              ].join('\n')
+            });
+
+      - name: Commit and Push Changes (embrace the mulch)
         run: |
           git config user.name "garden-bot"
           git config user.email "garden-bot@users.noreply.github.com"
@@ -48,3 +68,20 @@ jobs:
             git commit -m "chore(garden): refresh story and image"
             git push
           fi
+
+      - name: Chaos Mode Confessional (direct push to main/master)
+        if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master') }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+              body: [
+                '⚠️ CHAOS MODE: This was merged directly from main/master.',
+                '',
+                'No detours through a branch. No PR velvet rope. Just raw chlorophyll energy.',
+                'Proceed knowing that reviewers were bypassed in service of speed and spectacle.'
+              ].join('\n')
+            });


### PR DESCRIPTION
Update GitHub Actions workflows with satirical names, descriptions, and add "Chaos Mode" comments for direct pushes to `main`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4997439a-db17-4d52-bff3-ba86d26a1a0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4997439a-db17-4d52-bff3-ba86d26a1a0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

